### PR TITLE
Adding MedQA and general QandA finetuning stuff

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,96 @@
+# Recording my experience getting set up.
+Below I go through the process of getting setup on labscale-ai. The process should be relatively straightforward, especially if you have experience navigating huggingface.
+
+### 1. Clone Repo
+`git clone https://github.com/BillHoweLab/lab-scale-ai.git`
+
+### 2. Install Requirements 
+First, create an env using your favorite env manager (I like to use conda, so `conda create -n "labscale" python=3.9`). Note that I used python 3.9 - I think python>=3.9 should be fine.
+
+Then:
+
+```
+cd lab-scale-ai
+pip install -r requirements.txt
+```
+
+### 3. Make sure you have the proper tokens.
+You'll need an account with huggingface. You can get a token from the account here: [https://huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
+
+You'll also want an account with weights and biases. Then, make a new project, and it will provide you with a token.
+
+### 4. Validate that everything works.
+Run `python finetune_summarization.py` with the default arguments. You should be prompted to put in your HF and WandB tokens. If everything was installed properly, this should start to finetune the default opt model. 
+
+This is where you're likely to encounter any environment issues!!
+
+Resolve environment issues on the default finetuning before moving on.
+
+### 5. Grab a large model. 
+Once you've validated that the environment and install are all working as expected, you can download one of the huggingface larger models. 
+
+Start with something like Llama, you'll have to download the model weights locally. To do this, you can go somewhere like here: [https://huggingface.co/daryl149/llama-2-7b-chat-hf](https://huggingface.co/daryl149/llama-2-7b-chat-hf) and clone the repository directly into your local branch using `git lfs` (follow the instructions under Clone Repository on the huggingface model page)
+
+*Note*: If you (like me) were running on a remote system that didn't have git lfs installed and you don't have sudo access, you can install git lfs like:
+
+```
+wget https://github.com/git-lfs/git-lfs/releases/download/v3.2.0/git-lfs-linux-amd64-v3.2.0.tar.gz
+tar -xzf git-lfs-linux-amd64-v3.2.0.tar.gz
+PATH=$PATH:/<ABSOLUTE-PATH>/git-lfs-3.2.0/
+git lfs install
+git lfs version
+```
+
+where `<ABSOLUTE-PATH>` is the path to your current directory. 
+
+### 6. Your own task.
+Now, to finetune on your own task. 
+
+In my case, I was setting up a version of the MedQA question/answer medical task (based on USMLE exam questions). This lives here now [https://huggingface.co/datasets/lurosenb/medqa](https://huggingface.co/datasets/lurosenb/medqa)
+
+Sometimes, the dataset is not formatted properly for finetuning, so you need to make a slightly modified verison of the dataset.
+
+For example, here I found a version of the dataset I liked. I then downloaded it in a notebook
+```
+from datasets import load_dataset
+
+dataset = load_dataset("medalpaca/medical_meadow_medqa")
+```
+And then ran whatever processing I needed (in my case, just to create the proper splits)
+```
+train_test_split = dataset["train"].train_test_split(test_size=0.4)
+test_validation_split = train_test_split["test"].train_test_split(test_size=0.5)
+
+final_dataset = {
+    "train": train_test_split["train"],
+    "test": test_validation_split["test"],
+    "validation": test_validation_split["train"]
+}
+```
+Here, you might have to rename columns, remove NaNs, etc.
+
+Finally, I saved my newly created datasets to individual jsons (apologies for the redundancy). This is to prepare them for upload to huggingface
+```
+import json
+
+def save_to_json(dataset_split, filename):
+    with open(filename, 'w') as file:
+        data = [item for item in dataset_split]
+        json.dump(data, file, indent=4)
+
+# save each split to a separate json file
+save_to_json(final_dataset["train"], 'train_dataset.json')
+save_to_json(final_dataset["test"], 'test_dataset.json')
+save_to_json(final_dataset["validation"], 'validation_dataset.json')
+```
+
+### 7. Run with custom command line arguments.
+This is where you are most likely to customize metrics, and may need to customize certain aspects of the finetuning process (hopefully not!).
+
+The arguments for the MedQA finetuning task are:
+```
+python finetune_summarization.py --model_id llama-2-7b-chat-hf --dataset lurosenb/medqa --input_col input --target_col output  --train_slice train --validation_slice validation --test_slice test --wandb_logging True --wandb_name medqa --max_steps 80 --compute_summarization_metrics False --compute_qanda_metrics True --start_prompt “### Consider the following question with context:” --end_prompt “ ### Please answer with one of the options listed in the brackets:”
+```
+Note that the `input_col` and `target_col` should match your huggingface dataset column names, and that your filenames should be `train`, `validation` and `test`.
+
+Good luck!

--- a/tasks/evaluate_qanda.py
+++ b/tasks/evaluate_qanda.py
@@ -1,0 +1,301 @@
+import evaluate
+import numpy as np
+import json
+import argparse
+import torch
+import wandb
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from datasets import load_dataset
+from peft import PeftModel
+from typing import Iterable
+from tqdm import tqdm
+from os import path, makedirs, getenv
+
+from openai_chat_api import DialogueBot
+from generate_from_hf_model import generate_from_prompt
+
+from collections import Counter
+import re
+import string
+from typing import Optional, List
+
+#####
+# TODO: Below is partially adapted better answer parsing from  
+# https://github.com/vlievin/medical-reasoning/blob/master/medical_reasoning/models/functional/infer_answer.py
+# to be completed, and new metric added.
+
+def parse_options_from_input(input_question: str) -> dict:
+    # extract the options part from the input question
+    options_str = re.search(r"\{(.+?)\}$", input_question)
+    if options_str:
+        options_str = options_str.group(1)
+        options = dict(item.split(': ') for item in options_str.split(', '))
+        return options
+    else:
+        return {}
+
+def get_start_indices(target: str, pattern: str) -> list[int]:
+    try:
+        matches = re.finditer(pattern, target)
+        return [m.start() for m in matches]
+    except Exception as exc:
+        return []
+
+def get_first_match(query, choices, keys, op=min):
+    assert len(choices) == len(keys)
+    indices = [(key, get_start_indices(query, o)) for key, o in zip(keys, choices)]
+    indices = list(filter(lambda x: len(x[1]), indices))
+    if len(indices):
+        return op(indices, key=lambda x: x[1])[0]
+    else:
+        return None
+
+def infer_answer_from_input(input_question: str, target_answer: str) -> Optional[str]:
+    options = parse_options_from_input(input_question)
+    if not options:
+        return None
+
+    # check if the target answer is directly one of the option keys
+    if target_answer.strip() in options:
+        return target_answer.strip()
+
+    # direct match with the provided options' values
+    for key, value in options.items():
+        if value.strip() == target_answer.strip():
+            return key
+
+    # use regex patterns to match the answer
+    option_symbols = list(options.keys())
+    option_values = list(options.values())
+    option_symbols_re = [rf"{re.escape(o)}(\)|:|\.|,| )" for o in option_symbols]
+
+    # try to match using option symbols
+    match = get_first_match(target_answer, option_symbols_re, option_symbols)
+    if match is not None:
+        return match
+
+    # try to match using the full text of the options
+    match = get_first_match(target_answer, option_values, option_symbols)
+    if match is not None:
+        return match
+
+    return None
+
+###########
+# Following code from SQUAD, here:
+# https://github.com/huggingface/transformers/blob/main/src/transformers/data/metrics/squad_metrics.py
+
+def normalize_answer(s):
+    """Removing articles and punctuation, and standardizing whitespace are all typical text processing steps."""
+    import string, re
+
+    def remove_articles(text):
+        regex = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+        return re.sub(regex, " ", text)
+
+    def white_space_fix(text):
+        return " ".join(text.split())
+
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return "".join(ch for ch in text if ch not in exclude)
+
+    def lower(text):
+        return text.lower()
+
+    return white_space_fix(remove_articles(remove_punc(lower(s))))
+
+def get_tokens(s):
+    if not s:
+        return []
+    return normalize_answer(s).split()
+
+def compute_exact(a_gold, a_pred):
+    return int(normalize_answer(a_gold) == normalize_answer(a_pred))
+
+def compute_f1(a_gold, a_pred):
+    gold_toks = get_tokens(a_gold)
+    pred_toks = get_tokens(a_pred)
+    common = Counter(gold_toks) & Counter(pred_toks)
+    num_same = sum(common.values())
+    if len(gold_toks) == 0 or len(pred_toks) == 0:
+        # If either is no-answer, then F1 is 1 if they agree, 0 otherwise
+        return int(gold_toks == pred_toks)
+    if num_same == 0:
+        return 0
+    precision = 1.0 * num_same / len(pred_toks)
+    recall = 1.0 * num_same / len(gold_toks)
+    f1 = (2 * precision * recall) / (precision + recall)
+    return f1
+
+############
+
+def evaluate_hf_model_qa(model: AutoModelForCausalLM, 
+                         tokenizer: AutoTokenizer, 
+                         data: Iterable,
+                         start_prompt: str='### Consider the following question with context: ',
+                         end_prompt: str=' ### Please answer with one of the options listed in the brackets:',
+                         question_column: str='input',
+                         answer_column: str='output',
+                         max_samples: int=None,
+                         min_new_tokens: int=0,
+                         max_new_tokens: int=50,
+                         remove_suffix: str=None,
+                         device: str='cuda') -> dict:
+    """
+    Evaluate a Hugging Face model on a QA task.
+    """
+    exact_match, f1 = [], []
+    model.to(device)  # Ensure the model is on the correct device
+
+    for idx in tqdm(range(min(max_samples, len(data))), desc='Evaluating QA model'):
+        question = data[idx][question_column]
+        ground_truth = data[idx][answer_column]
+
+        # Generate and decode the output string, removing the special tokens and any suffixes
+        decoded = generate_from_prompt(model=model, 
+                                       tokenizer=tokenizer, 
+                                       input_data=question, 
+                                       start_prompt=start_prompt, 
+                                       end_prompt=end_prompt, 
+                                       min_new_tokens=min_new_tokens,
+                                       max_new_tokens=max_new_tokens)
+
+        # Remove the suffix if specified - note that Mistral-Instruct models add a </s> suffix to specify the end of the output
+        if remove_suffix is not None:
+            decoded = decoded.replace(remove_suffix, '')
+
+        exact_match.append(compute_exact(decoded, ground_truth))
+        f1.append(compute_f1(decoded, ground_truth))
+
+    return {
+        'exact_match': np.mean(exact_match),
+        'squad_f1_score': np.mean(f1)
+    }
+
+
+def evaluate_openai_model_qa(bot: DialogueBot,
+                             data: Iterable, 
+                             question_column: str,
+                             answer_column: str,
+                             max_samples: int=None) -> dict:
+    """
+    Evaluate an OpenAI model on a dataset using QA metrics.
+    """
+
+    exact_match, f1 = [], []
+
+    # Iterate over the dataset
+    for idx in tqdm(range(min(max_samples, len(data))), desc='Evaluating OpenAI QA model'):
+
+        # Create the input string, framing it as a question
+        input = f"Question: {data[idx][question_column]}\nAnswer:"
+        
+        # Get the model's response, which is the generated answer
+        output = bot.return_bot_response(input)
+        
+        # Compute metrics
+        exact_match.append(exact_match_score(output, data[idx][answer_column]))
+        f1.append(f1_score(output, data[idx][answer_column]))
+
+    return {
+        'exact_match': np.mean(exact_match),
+        'squad_f1_score': np.mean(f1),
+    }
+
+if __name__ == '__main__':
+
+    # Parse the command line arguments
+    parser = argparse.ArgumentParser(description='Evaluate a model on a QA task.')
+
+    # Model arguments
+    parser.add_argument('--model_type', type=str, help='The type of model to evaluate (Huggingface or OpenAI)', default='hf')
+    parser.add_argument('--hf_model_id', type=str, help='The Huggingface model to evaluate', default='llama-2-7b-chat-hf')
+    parser.add_argument('--oai_model_id', type=str, help='The OpenAI model ID to use', default='gpt-3.5-turbo')
+
+    # Dataset arguments
+    parser.add_argument('--dataset', type=str, help='The dataset to evaluate on', default='lurosenb/medqa')
+    parser.add_argument('--dataset_revision', type=str, help='The revision of the dataset to use', default='latest')
+    parser.add_argument('--split', type=str, help='The split of the dataset to evaluate on', default='test')
+    parser.add_argument('--question_column', type=str, help='The name of the question column in the dataset', default='input')
+    parser.add_argument('--answer_column', type=str, help='The name of the answer column in the dataset', default='output')
+    parser.add_argument('--max_samples', type=int, help='The maximum number of samples to evaluate', default=200)
+
+    # Generation arguments
+    parser.add_argument('--max_tokens', type=int, help='The maximum number of tokens to generate', default=50)
+    parser.add_argument('--remove_suffix', type=str, help='The suffix to remove from the generated output', default=None)
+
+    # Environment and reproducibility arguments
+    parser.add_argument('--device', type=str, help='The device to use for inference', default='cuda')
+    parser.add_argument('--seed', type=int, help='The random seed to use', default=42)
+    parser.add_argument('--save_dir', type=str, help='The directory to save the results to', default='results')
+
+    # W&B logging arguments
+    parser.add_argument('--wandb_logging', type=str, default='False', help='Whether to log to W&B.')
+    parser.add_argument('--wandb_name', type=str, default='qa_eval', help='The name of the W&B project, for logging.')
+    parser.add_argument('--wandb_api_var', type=str, default='WANDB_API_KEY', help='Name of the WandB API key variable name.')
+
+    # Parse the arguments
+    args = parser.parse_args()
+
+    # Set the random seed for reproducibility
+    torch.manual_seed(args.seed)
+
+    # Initialize W&B
+    if args.wandb_logging == 'True':
+        wandb.login(key=getenv(args.wandb_api_var))
+        wandb.init(project=args.wandb_name, 
+                   name=args.run_name, 
+                   config=args)
+    
+    # Load the test split of the dataset
+    print('Loading dataset: ', args.dataset)
+    data = load_dataset(args.dataset, args.dataset_revision, split=args.split)
+
+    # Model evaluation logic based on the model type
+    if args.model_type == 'hf':
+        # Load the Hugging Face model and tokenizer
+        print('Loading Hugging Face model: ', args.hf_model_id)
+        tokenizer = AutoTokenizer.from_pretrained(args.hf_model_id)
+        model = AutoModelForCausalLM.from_pretrained(args.hf_model_id).to(args.device)
+        model.eval()
+
+        # Evaluate the Hugging Face model
+        print('Evaluating Hugging Face model on QA task: ', args.hf_model_id)
+        qa_metrics = evaluate_hf_model_qa(model, tokenizer, data, args.question_column, args.answer_column, args.max_samples)
+
+    elif args.model_type == 'openai':
+        # NOTE: OpenAI Diaglogue bot QandA task has not been tested
+        # TODO: Test
+        # Evaluate the OpenAI model
+        print('Evaluating OpenAI model on QA task: ', args.oai_model_id)
+        bot = DialogueBot(model=args.oai_model_id, system_prompt=args.system_prompt)
+        qa_metrics = evaluate_hf_model_qa(model, tokenizer, data, args.question_column, args.answer_column, args.max_samples, args.device)
+
+    else:
+        raise ValueError('Invalid model type: ', args.model_type)
+
+    # Print the metrics to the console
+    print('Model QA Metrics:')
+    for key, value in qa_metrics.items():
+        print(f'{key}: {value}')
+
+    # Add the model and dataset names to the metrics dictionary
+    metrics = {**vars(args), **qa_metrics}
+
+    # Save the metrics to a JSON file
+    model_id = args.hf_model_id if args.model_type == 'hf' else args.oai_model_id
+    save_path = path.join(args.save_dir, f'{model_id.replace("/", "-")}_qa_metrics.json')
+    print('Saving QA metrics to: ', save_path)
+
+    if not path.exists(args.save_dir):
+        makedirs(args.save_dir)
+
+    with open(save_path, 'w') as f:
+        json.dump(metrics, f)
+
+    # Log the metrics to W&B
+    if args.wandb_logging == 'True':
+        wandb.log(metrics)
+        wandb.finish()


### PR DESCRIPTION
Working on the Privacy issue #8 , need to start by adding a reasonable QandA from medical domain. Added MedQA here: https://huggingface.co/datasets/lurosenb/medqa . 

Added an evaluate_qanda.py script with some QandA specific functions. Piggybacked off of @BeanHam 's finetune_summarization file, as it was my starting point and there was lots of overlap in the implementation. I vote we rename "finetune_summarization" to just "finetune_runner" and use it to run any task (with proper command line customization, as demonstrated. 

Still need to improve on the QandA metrics (for MedQA, multiple choice means we should have an accuracy score with better answer parsing, not just the SQUAD style f1 score. I added some work to that end but its incomplete).

Also, didn't run tests beyond finetuning Llama. trying not to get too distracted by experiments, as my goal is to move on quickly to the privacy finetuning task which is non trivial.

Also added a readme which catalogued the process of getting my task going. Hopefully it's useful for someone!